### PR TITLE
feat: Compress sharable link payload to fix URI Too Long error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "chart.js": "^4.4.9",
         "chartjs-plugin-annotation": "^3.1.0",
         "chartjs-plugin-zoom": "^2.2.0",
+        "pako": "^2.1.0",
         "react": "^18.2.0",
         "react-chartjs-2": "^5.3.0",
         "react-dom": "^18.2.0",
@@ -20,6 +21,7 @@
       "devDependencies": {
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
+        "@types/pako": "^2.0.3",
         "@types/react": "^18.2.66",
         "@types/react-dom": "^18.2.22",
         "@types/styled-components": "^5.1.34",
@@ -1752,6 +1754,12 @@
       "dependencies": {
         "undici-types": "~6.21.0"
       }
+    },
+    "node_modules/@types/pako": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.3.tgz",
+      "integrity": "sha512-bq0hMV9opAcrmE0Byyo0fY3Ew4tgOevJmQ9grUhpXQhYfyLJ1Kqg3P33JT5fdbT2AjeAjR51zqqVjAL/HMkx7Q==",
+      "dev": true
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.14",
@@ -4222,6 +4230,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="
     },
     "node_modules/parent-module": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "react-chartjs-2": "^5.3.0",
     "react-dom": "^18.2.0",
     "styled-components": "^6.1.11",
-    "uuid": "^11.1.0"
+    "uuid": "^11.1.0",
+    "pako": "^2.1.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.6.3",
@@ -31,6 +32,7 @@
     "@types/styled-components": "^5.1.34",
     "@types/testing-library__jest-dom": "^5.14.9",
     "@types/uuid": "^10.0.0",
+    "@types/pako": "^2.0.3",
     "@typescript-eslint/eslint-plugin": "^7.2.0",
     "@typescript-eslint/parser": "^7.2.0",
     "@vitejs/plugin-react": "^4.2.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 // import React from 'react';
 import { useState, useEffect } from 'react'; // Removed React import, kept hooks
 import styled from 'styled-components';
+import pako from 'pako';
 import LoanForm from './components/LoanForm';
 import LoanList from './components/LoanList';
 import { useAppStateWithEdit, useAppDispatch } from './contexts/AppContext'; 
@@ -81,8 +82,11 @@ function App() {
     const loadStateParam = params.get('loadState');
     if (loadStateParam) {
       try {
-        const decodedJsonState = atob(decodeURIComponent(loadStateParam));
-        const loadedState = JSON.parse(decodedJsonState);
+        const base64DecodedBinaryString = atob(decodeURIComponent(loadStateParam));
+        const compressedDataArray = new Uint8Array(base64DecodedBinaryString.length);
+        for (let i = 0; i < base64DecodedBinaryString.length; i++) { compressedDataArray[i] = base64DecodedBinaryString.charCodeAt(i); }
+        const decompressedJsonState = pako.inflate(compressedDataArray, { to: 'string' });
+        const loadedState = JSON.parse(decompressedJsonState);
         // Ensure loadedState conforms to at least part of AppState structure
         if (loadedState && loadedState.loans) { // Basic check
           dispatch({ type: 'LOAD_STATE', payload: loadedState });

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1,6 +1,7 @@
 // src/components/SettingsModal.tsx
 import React from 'react';
 import styled from 'styled-components';
+import pako from 'pako';
 import { useAppState, useAppDispatch } from '../contexts/AppContext';
 import Modal from './Modal'; 
 
@@ -106,7 +107,9 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose }) => {
       fyStartMonth: fyStartMonth, // Include fyStartMonth in shared state
     };
     const jsonState = JSON.stringify(stateToShare);
-    const base64State = btoa(jsonState); 
+    const compressed = pako.deflate(jsonState);
+    const binaryString = String.fromCharCode.apply(null, Array.from(new Uint8Array(compressed)));
+    const base64State = btoa(binaryString);
     const shareUrl = `${window.location.origin}${window.location.pathname}?loadState=${encodeURIComponent(base64State)}`;
 
     try {


### PR DESCRIPTION
The application state in sharable links was previously serialized to JSON and then Base64 encoded, leading to "Error: URI Too Long" for large datasets (e.g., many loans with extensive histories).

This change introduces compression to the process:
1. The application state (JSON string) is now compressed using `pako.deflate` before being Base64 encoded in `src/components/SettingsModal.tsx`.
2. When loading state from a URL, the Base64 decoded string is first decompressed using `pako.inflate` before being parsed as JSON in `src/App.tsx`.

This significantly reduces the length of the `loadState` URL parameter, mitigating the "URI Too Long" error and allowing for larger application states to be shared via links.

The `pako` library has been added as a dependency.